### PR TITLE
Fix typos in README.md that can cause confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ _See examples for each of them above._
 ```js
 ...
 let frame = {
-	"proPrice": ".planName:contains('Pro') + span@price"
+	"proPrice": ".planName:contains('Pro') + span @ price"
 }
 
 let result = $('body').scrape(frame, { string: true })
@@ -397,7 +397,7 @@ let frame = {
 			"price": ".planPrice @ price",
 			"image": {
 				"url": "img @ src",
-				"link": "a @href"
+				"link": "a @ href"
 			}
 		}]
 	}	


### PR DESCRIPTION
I added in spaces after @ portions of inline selectors.