### PR TITLE
Remove weird, unused, breaking behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,16 +19,11 @@ let parseData = function (data, regex, {
 				rgx = new RegExp(regex, 'gim')
 			}
 			extracted = rgx.exec(data)
-			if (multiple) {
-				result = extracted
-				// result = data.match(rgx)
+			
+			if (extracted[1]) {
+				result = extracted[1]
 			} else {
-				if (extracted[1]) {
-					result = extracted[1]
-				} else {
-					result = extracted[0]
-				}
-				// result = data.match(rgx)[0]
+				result = extracted[0]
 			}
 		} catch (error) {
 			// console.log("Regex error: ", error)


### PR DESCRIPTION
There was an if statement in the `parseData` function (in the npm module, it is in `modules/parse.fn.js`) which would return the full `Array` returned by `rgx.exec(data)`, instead of the `String` indicating the match itself.
The if statement did not seem to be actually used anywhere; it only broke things (for example, inline parsing in inline Array selectors; for example, scraping with the following frame
```javascript
{"myInfo":["a @ href || [a-z]+"]}
```
would cause an error because parseData (in this case, which had multiple set to true) returned an Array, not a String). This PR removes that if statement.